### PR TITLE
correct typo in 'How Did You Find Me?' drop-down menu

### DIFF
--- a/content/contact/index.html
+++ b/content/contact/index.html
@@ -75,8 +75,8 @@ Other
 <select id="Field108" name="Field108" class="" tabindex="6" >
 <option value="" selected="selected">
 </option>
-<option value="Previous Clien" >
-Previous Clien
+<option value="Previous Client" >
+Previous Client
 </option>
 <option value="Client Referral" >
 Client Referral
@@ -181,4 +181,3 @@ required  ></textarea>
 <input type="hidden" id="idstamp" name="idstamp" value="4zu9/SrAUpZqEoKfyPHAg7mPX44LgNhxA9eXTwrSnVA=" />
 </div>
 </form>
-


### PR DESCRIPTION
Hi Evan!

I was looking at your site and found a typo where it said "Previous Clien" instead of "Previous Client". I found where I think it's located. Joe challenged me to fork and do a pull request. Hope it helps.

:D Michaela
